### PR TITLE
Ajout du paquet freetype2 pour les polices

### DIFF
--- a/install.md
+++ b/install.md
@@ -426,7 +426,7 @@ Pour Nvidia, c’est un casse-tête au niveau des pilotes propriétaires. Le plu
 Dans le cas d’une machine virtuelle, j’ai utilisé le paquet **xf86-video-vesa**. On passe ensuite à l’installation des polices. Voici la ligne de commande pour les principales.
 
 ```
-pacman -S ttf-{bitstream-vera,liberation,freefont,dejavu}
+pacman -S ttf-{bitstream-vera,liberation,freefont,dejavu} freetype2
 ```
 
 **Note 2 :** pour les polices Microsoft, le paquet ttf-ms-fonts, elles sont sur le dépôt AUR, donc il faut utiliser yaourt pour les récupérer et les installer.


### PR DESCRIPTION
Ajout du paquet [freetype2](https://www.archlinux.org/packages/extra/x86_64/freetype2/).

Après moult galères pour avoir des polices potables sous Arch, je suis tombé là-dessus: https://www.reddit.com/r/archlinux/comments/7242ig/why_does_arch_not_come_with_decent_font_settings/dnfkyqy/. (faire fi de la mention de testing, le paquet est à jour désormais)

Pas besoin de s'embêter avec des fonts.conf dans tous les sens, une simple installation de ce paquet suffit à voir des polices correctes partout. Pour ma part je prends Windows 10 en référence (oui, au moins les polices sont propres nativement), et c'est la solution qui permet de s'en rapprocher le plus avec le moins d'effort. C'est presque magique 😄 